### PR TITLE
Lower default eyepoint.

### DIFF
--- a/c170b-set.xml
+++ b/c170b-set.xml
@@ -150,7 +150,7 @@
             <internal type="bool" archive="y">true</internal>
             <config>
                 <x-offset-m archive="y" type="double">-0.16</x-offset-m>
-                <y-offset-m archive="y" type="double">0.600</y-offset-m>
+                <y-offset-m archive="y" type="double">0.500</y-offset-m>
                 <z-offset-m archive="y" type="double">2.66</z-offset-m>
                 <pitch-offset-deg type="double">-12</pitch-offset-deg>
                 <default-field-of-view-deg>75</default-field-of-view-deg>


### PR DESCRIPTION
It shouldn't be possible to see the runway straight ahead when the tailwheel is on the ground. Also makes it more natural to look out the side windows.